### PR TITLE
Allow Amazon AppFlow

### DIFF
--- a/config/service-control-policies/LZA-Guardrails-Sandbox.json
+++ b/config/service-control-policies/LZA-Guardrails-Sandbox.json
@@ -113,7 +113,6 @@
         "ram:EnableSharingWithAwsOrg*",
         "lightsail:*",
         "gamelift:*",
-        "appflow:*",
         "iq:*",
         "account:P*",
         "account:GetAl*",

--- a/config/service-control-policies/LZA-Guardrails-Sensitive.json
+++ b/config/service-control-policies/LZA-Guardrails-Sensitive.json
@@ -113,7 +113,6 @@
         "ram:EnableSharingWithAwsOrg*",
         "lightsail:*",
         "gamelift:*",
-        "appflow:*",
         "iq:*",
         "account:P*",
         "account:GetAl*",

--- a/config/service-control-policies/LZA-Guardrails-Unclass.json
+++ b/config/service-control-policies/LZA-Guardrails-Unclass.json
@@ -113,7 +113,6 @@
         "ram:EnableSharingWithAwsOrg*",
         "lightsail:*",
         "gamelift:*",
-        "appflow:*",
         "iq:*",
         "account:P*",
         "account:GetAl*",


### PR DESCRIPTION
*Issue #, if available:* Issue #1 

*Description of changes:*
Removed Amazon AppFlow from the Sandbox, Unclass, and Sensitive SCP's to allow the use of the service. AppFlow has been assessed by CCCS. https://aws.amazon.com/compliance/services-in-scope/CCCS/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
