### PR TITLE
ENHANCEMENT: Added AWS Config Aggregator

### DIFF
--- a/config/security-config.yaml
+++ b/config/security-config.yaml
@@ -103,6 +103,9 @@ iamPasswordPolicy:
 awsConfig:
   enableConfigurationRecorder: true
   enableDeliveryChannel: true
+  aggregation:
+    enable: true
+    delegatedAdminAccount: Audit
   ruleSets:
     - deploymentTargets:
       ## GLOBAL Section for config rules across all OUs + Management Account


### PR DESCRIPTION
(enhancement) AWS Config Aggregator is enabled and configured to leverage the `Audit` account.

*Issue #, if available:*
https://github.com/aws-samples/landing-zone-accelerator-on-aws-for-cccs-medium/issues/3

*Description of changes:*
+ Enables the AWS Config Aggregator in the `Audit` account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
