### PR TITLE
feat: support custom health check paths for target groups

### DIFF
--- a/post-deployment.md
+++ b/post-deployment.md
@@ -61,6 +61,7 @@ __Note__: The sample below is in standard JSON format, not DynamoDB JSON. When a
     "id": "App1",
     "targetAlbDnsName": "internal-Core-mydevacct1-alb-123456789.ca-central-1.elb.amazonaws.com",
     "targetGroupDestinationPort": 443,
+    "healthCheckPath": "/",
     "targetGroupProtocol": "HTTPS",
     "vpcId": "vpc-0a6f44a80514daaaf",
     "rule": {
@@ -81,6 +82,7 @@ __Note__: The sample below is in standard JSON format, not DynamoDB JSON. When a
 - `paths` and `hosts` are both optional, but one of the two must be supplied
 - `priority` must be unique and is used to order the listener rules. Priorities should be spaced at least 40 apart to allow for easy insertion of new applications and forwarder rules.
 - the provided `targetAlbDnsName` must resolve to addresses within a [supported](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html) IP address space.
+- `healthCheckPath` optional (defaulting to "/").
 
 ### Troubleshooting ALB forwarding
 For tips on troubleshooting issues with ALB forwarding rules see the [FAQ about Application Load Balancers Forwarding](./documentation/FAQ.md#Application-Load-Balancers-Forwarding)

--- a/source/alb-forwarder/alb-target-record-monitor.ts
+++ b/source/alb-forwarder/alb-target-record-monitor.ts
@@ -23,6 +23,8 @@ import {
   ModifyRuleCommandInput,
   ProtocolEnum,
   TargetTypeEnum,
+  ModifyTargetGroupCommand,
+  ModifyTargetGroupCommandInput
 } from '@aws-sdk/client-elastic-load-balancing-v2';
 
 import * as _ from 'lodash';
@@ -37,13 +39,32 @@ const sleep = (ms: number) => {
   });
 };
 
-const createTargetGroup = async (name: string, port: number, vpcId: string, protocol: ProtocolEnum) => {
+const updateTargetGroupHealthCheck = async (
+  targetGroupArn: string,
+  healthCheckPath: string
+) => {
+  const params: ModifyTargetGroupCommandInput = {
+    TargetGroupArn: targetGroupArn,
+    HealthCheckPath: healthCheckPath,
+  };
+  return elbv2.send(new ModifyTargetGroupCommand(params));
+};
+
+const healthCheckPathChanged = (oldRecord: any, newRecord: any): boolean => {
+  const oldPath = oldRecord.healthCheckPath || "/";
+  const newPath = newRecord.healthCheckPath || "/";
+  return oldPath !== newPath;
+};
+
+
+const createTargetGroup = async (name: string, port: number, vpcId: string, protocol: ProtocolEnum, healthCheckPath: string = "/") => {
   const targetGroupParams = {
     Name: name,
     Port: port,
     Protocol: protocol,
     VpcId: vpcId,
     TargetType: TargetTypeEnum.IP,
+    HealthCheckPath: healthCheckPath,
   };
 
   return elbv2.createTargetGroup(targetGroupParams);
@@ -254,6 +275,7 @@ const createRecordHandler = async (record: any) => {
       record.targetGroupDestinationPort,
       record.vpcId,
       record.targetGroupProtocol,
+      record.healthCheckPath || "/"
     );
 
     const targetGroupArn = targetGroup?.TargetGroups?.[0].TargetGroupArn ?? '';
@@ -351,6 +373,15 @@ const updateRecordHandler = async (newRecord: any, oldRecord: any) => {
       }
       await updateRulePriority(newRecord.metadata.ruleArn, newRecord.rule.condition.priority);
     }
+    
+    if (healthCheckPathChanged(oldRecord, newRecord)) {
+      console.log(`Detected a health check path change. Updating target group health check in-place for ${newRecord.metadata.targetGroupArn}`);
+      await updateTargetGroupHealthCheck(
+        newRecord.metadata.targetGroupArn,
+        newRecord.healthCheckPath || "/"
+      );
+    }
+
     if (targetGroupChange(oldRecord, newRecord)) {
       console.log(
         `Detected a target group change. deleting target group  ${newRecord.metadata.targetGroupArn} and creating a new target group`,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Extend createTargetGroup() to accept a healthCheckPath parameter (default: '/') and update createRecordHandler() to pass record.healthCheckPath or '/' when creating target groups.

- Add healthCheckPathChanged() helper to detect changes and introduce updateTargetGroupHealthCheck() to modify the health check path in place during updates.

- Update updateRecordHandler() to update the health check path if it changes, while retaining delete/recreate logic for other target group attributes.

This change enables users to configure target group health check paths via DynamoDB entries.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
