### PR TITLE
fix: typo in SandboxAllowedRegions

### DIFF
--- a/config/replacements-config.yaml
+++ b/config/replacements-config.yaml
@@ -20,7 +20,7 @@ globalReplacements:
     value:
       - "ca-central-1"
       - "us-east-1"
-      - "us-east-1"
+      - "us-east-2"
       - "us-west-1"
       - "us-west-2"
   # List of enabled regions excluding the home region


### PR DESCRIPTION
*Description of changes:* Fixed a duplicate region definition in the SandboxAllowedRegions configuration where us-east-1 was listed twice in replacements-config.yaml. Removed the duplicate entry while maintaining the correct list of allowed regions (ca-central-1, us-east-1, us-east-2, us-west-1, us-west-2) for sandbox environments. This change ensures proper region configuration and prevents potential issues from duplicate entries.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
