### PR TITLE
update scp's to include support-console to working with upcoming AWS …

### DIFF
--- a/config/service-control-policies/LZA-Guardrails-Sandbox.json
+++ b/config/service-control-policies/LZA-Guardrails-Sandbox.json
@@ -157,6 +157,7 @@
         "shield:*",
         "sts:*",
         "support:*",
+        "support-console:*",        
         "trustedadvisor:*",
         "waf-regional:*",
         "waf:*",

--- a/config/service-control-policies/LZA-Guardrails-Sensitive.json
+++ b/config/service-control-policies/LZA-Guardrails-Sensitive.json
@@ -240,6 +240,7 @@
         "shield:*",
         "sts:*",
         "support:*",
+        "support-console:*",        
         "trustedadvisor:*",
         "waf-regional:*",
         "waf:*",

--- a/config/service-control-policies/LZA-Guardrails-Unclass.json
+++ b/config/service-control-policies/LZA-Guardrails-Unclass.json
@@ -218,6 +218,7 @@
         "shield:*",
         "sts:*",
         "support:*",
+        "support-console:*",        
         "trustedadvisor:*",
         "waf-regional:*",
         "waf:*",


### PR DESCRIPTION
*Description of changes:*
- Updated the SCPs to include support-console:*, allowing AWS Support Center Console API operations ahead of IAM authorization enforcement beginning November 16, 2026.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
